### PR TITLE
Add Ctrl-Q/Command-Q to quit 

### DIFF
--- a/esphomeflasher/gui.py
+++ b/esphomeflasher/gui.py
@@ -195,7 +195,8 @@ class MainFrame(wx.Frame):
         file_menu = wx.Menu()
         quit_item = file_menu.Append(
             wx.ID_EXIT, "Quit\tCtrl-Q" if sys.platform != "darwin" else "Quit\tCmd-Q", "Quit FujiNet-Flasher")
-        menubar.Append(file_menu, "&File")
+        if sys.platform != "darwin":
+            menubar.Append(file_menu, "&File")
         self.SetMenuBar(menubar)
         self.Bind(wx.EVT_MENU, self._on_exit_app, quit_item)
 

--- a/esphomeflasher/gui.py
+++ b/esphomeflasher/gui.py
@@ -190,6 +190,7 @@ class MainFrame(wx.Frame):
     def __init__(self, parent, title):
         wx.Frame.__init__(self, parent, -1, title, style=wx.DEFAULT_FRAME_STYLE | wx.NO_FULL_REPAINT_ON_RESIZE)
 
+        # Add menu with quit option
         menubar = wx.MenuBar()
         file_menu = wx.Menu()
         quit_item = file_menu.Append(

--- a/esphomeflasher/gui.py
+++ b/esphomeflasher/gui.py
@@ -190,6 +190,14 @@ class MainFrame(wx.Frame):
     def __init__(self, parent, title):
         wx.Frame.__init__(self, parent, -1, title, style=wx.DEFAULT_FRAME_STYLE | wx.NO_FULL_REPAINT_ON_RESIZE)
 
+        menubar = wx.MenuBar()
+        file_menu = wx.Menu()
+        quit_item = file_menu.Append(
+            wx.ID_EXIT, "Quit\tCtrl-Q" if sys.platform != "darwin" else "Quit\tCmd-Q", "Quit FujiNet-Flasher")
+        menubar.Append(file_menu, "&File")
+        self.SetMenuBar(menubar)
+        self.Bind(wx.EVT_MENU, self._on_exit_app, quit_item)
+
         self._firmware = None
         self._port = None
         self._upload_baud_rate = 460800


### PR DESCRIPTION
Add support for `command-q` to quit the app (Windows & Linux should use `ctrl-q`.  

I was able to test this on macOS Ventura (13.x) & Windows 64-bit with Wine (32-bit Windows worked but the UI didn't render properly).  

Built assets are available in my GitHub Actions: https://github.com/benjamink/fujinet-flasher/actions/runs/16040417166

![Pasted_Image_7_2_25__11_55_PM](https://github.com/user-attachments/assets/5b8d0fa2-0162-454f-89e3-375726e5238b)
